### PR TITLE
Popup editor localization. Editable bug fixes. Unit tests

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -5,4 +5,5 @@ module.exports = {
   projections: require('./projection/index'),
   layout: require('./layout/index'),
   factory,
+  popupEditorPrompt: require('./popup-editor/index'),
 };

--- a/js/popup-editor/index.jade
+++ b/js/popup-editor/index.jade
@@ -1,6 +1,6 @@
 form.form-inline(style='padding: 5px; background: #e0e0e0')
   input.form-control.editor(type='text', value=value)
   &nbsp
-  button.btn.btn-primary.save(type='button') Save
+  button.btn.btn-primary.save(type='button')=saveButtonText
   &nbsp
-  button.btn.btn-default.cancel(type='button') Cancel
+  button.btn.btn-default.cancel(type='button')=cancelButtonText

--- a/js/popup-editor/index.js
+++ b/js/popup-editor/index.js
@@ -31,6 +31,8 @@ define([
       this.position = options.position;
       this.model = options.model;
       this.property = options.property;
+      this.saveButtonText = options.saveButtonText || 'Save';
+      this.cancelButtonText = options.cancelButtonText || 'Cancel';
     },
 
     getValue: function () {
@@ -54,7 +56,11 @@ define([
     render: function () {
       var val = this.getValue();
 
-      this.$el.html(template({ value: val }));
+      this.$el.html(template({
+        value: val,
+        saveButtonText: this.saveButtonText,
+        cancelButtonText: this.cancelButtonText,
+      }));
       this.$el.css({
         position: 'absolute',
         left: this.position.left,

--- a/js/projection/editable.js
+++ b/js/projection/editable.js
@@ -5,7 +5,7 @@ define([
   'component/grid/layout/template/editable.jade',
   'component/popup-editor/index',
   '../../less/editable.less',
-], function (_, $, BaseProjection, editableTemplate, prompt) {
+], function (_, $, BaseProjection, defaultEditableTemplate, prompt) {
   'use strict';
 
   function isReadonlyRow(item) {
@@ -20,6 +20,7 @@ define([
       'column.editable': [],
       'editable.icon.class': ['glyphicon', 'glyphicon-pencil'],
       'editable.tooltip.text': 'Edit',
+      'editable.template': defaultEditableTemplate,
     },
     name: 'column-editable',
     events: {
@@ -70,6 +71,7 @@ define([
         var columns = model.get('columns');
         var iconClasses = this.get('editable.icon.class');
         var tooltipText = this.get('editable.tooltip.text');
+        var editableTemplate = this.get('editable.template');
 
         _.each(this.viewConfig, function (view, key) {
           var column = columns[key] || { property: key };
@@ -125,11 +127,11 @@ define([
         e.target.tagName !== 'A' &&
         $(e.target).closest('.is-not-trigger').length === 0) {
         schema = arg.grid.options.get('schema');
-        let editor = this.viewConfig[property] || prompt;
+        let editor = this.viewConfig[arg.property] || prompt;
         editor({
           model: arg.model,
           schema: schema,
-          position: arg.grid.layout.container.offset(e.target),
+          position: arg.grid.layout.container.offset(e.currentTarget),
           property: property,
           onSubmit: model => {
             this.trigger('edit', model, property);

--- a/spec/editable-spec.js
+++ b/spec/editable-spec.js
@@ -1,8 +1,13 @@
-var expect = require('chai').expect;
 var sinon = require('sinon');
+var chai = require("chai");
+var sinonChai = require("sinon-chai");
+var util = require('./util');
 var EditableProjection = require('component/grid/projection/editable');
 var Base = require('component/grid/projection/base');
 var Response = require('component/grid/model/response');
+
+chai.should();
+chai.use(sinonChai);
 
 describe('projection editable', function () {
   it('receive array editable config', function () {
@@ -17,9 +22,9 @@ describe('projection editable', function () {
     });
     sinon.spy(model, 'patch');
     originalData.pipe(model);
-    expect(model.patch.called).to.be.true;
+    model.patch.should.have.been.called;
 
-    expect(Object.keys(model.viewConfig)).to.be.eql(['name', 'age']);
+    Object.keys(model.viewConfig).should.be.eql(['name', 'age']);
   });
 
   it('receive object editable config', function () {
@@ -37,8 +42,188 @@ describe('projection editable', function () {
     });
     sinon.spy(model, 'patch');
     originalData.pipe(model);
-    expect(model.patch.called).to.be.true;
+    model.patch.should.have.been.called;
 
-    expect(Object.keys(model.viewConfig)).to.be.eql(['name', 'age']);
+    Object.keys(model.viewConfig).should.be.eql(['name', 'age']);
+  });
+
+  it('supports localization of the tooltip', function () {
+    const editableTemplate = sinon.stub();
+
+    const tooltipText = 'Localized text';
+    var originalData = new Base();
+    const model = new EditableProjection({
+      'column.editable': {
+        name: sinon.spy(),
+      },
+      'editable.tooltip.text': tooltipText,
+      'editable.template': editableTemplate,
+    });
+
+    originalData.data = new Response({
+      value: [{ name: 'hello' }],
+      columns: {},
+    });
+    sinon.spy(model, 'patch');
+
+    originalData.pipe(model);
+
+    editableTemplate.should.have.been.calledWith(
+      util.objectPartialMatch(
+        ['$html', 'classes'], {
+          text: 'hello',
+          tooltipText,
+        }
+      ));
+    model.patch.should.have.been.called;
+  });
+
+  describe('during interaction calls editor on layout:click:cell event', function () {
+    class Arg {
+      constructor() {
+        this.model = {
+          id: 'abc',
+          description: 'some description',
+          $metadata: {
+            attr: {
+              class: ['row-class1', 'row-class2'],
+            },
+          },
+        };
+        this.property = 'description';
+        this.column = {
+          sortable: 'Description',
+          $metadata: {
+            'attr.head': { class: ['cell-head-class1', 'cell-head-class2'] },
+          },
+        };
+        this.schema = {};
+        this.position = 42;
+      }
+
+      withModel(model) {
+        this.model = model;
+        return this;
+      }
+
+      forProperty(property) {
+        this.property = property;
+        return this;
+      }
+
+      withColumn(column) {
+        this.column = column;
+        return this;
+      }
+
+      withSchema(schema) {
+        this.schema = schema;
+        return this;
+      }
+
+      build() {
+        var gridOptionsGet = sinon.stub();
+        gridOptionsGet.withArgs('schema').returns(this.schema);
+
+        var gridLayoutContainerOffset = sinon.stub();
+        gridLayoutContainerOffset.returns(this.position);
+
+        return {
+          header: { isHeader: false },
+          model: this.model,
+          property: this.property,
+          column: this.column,
+          grid: {
+            options: {
+              get: gridOptionsGet,
+            },
+            layout: {
+              container: {
+                offset: gridLayoutContainerOffset,
+              },
+            },
+          },
+        };
+      }
+    }
+
+    var event;
+
+    beforeEach(function (done) {
+      util.$container.one('click', function (evt) {
+        event = evt;
+        done();
+      });
+      util.$container.click();
+    });
+
+    afterEach(function () {
+      console.log('Doing cleanup');
+      util.cleanup();
+    });
+
+    it('for simple model', function () {
+      var editor = sinon.spy();
+
+      var editable = new EditableProjection({
+        'column.editable': {
+          description: editor,
+        },
+      });
+
+      let arg = new Arg();
+
+      editable.bubble('layout:click:cell', event, arg.build());
+
+      editor.should.have.been.calledWith(
+        util.objectPartialMatch(
+          ['onSubmit'], {
+            model: arg.model,
+            schema: arg.schema,
+            position: arg.position,
+            property: arg.property,
+          }));
+    });
+
+    it('for complex model with value mapping', function () {
+      var editor = sinon.spy();
+
+      var editable = new EditableProjection({
+        'column.editable': {
+          label: editor,
+        },
+      });
+
+      let arg = new Arg()
+        .withModel({
+          label: {
+            name: 'Label 1',
+            color: '#00ff0f',
+          },
+        })
+        .withColumn({
+          sortable: 'Name',
+          $metadata: {
+            map: {
+              name: 'name',
+              value(model) {
+                return model.label;
+              },
+            },
+          },
+        })
+        .forProperty('label');
+
+      editable.bubble('layout:click:cell', event, arg.build());
+
+      editor.should.have.been.calledWith(
+        util.objectPartialMatch(
+          ['onSubmit'], {
+            model: arg.model,
+            schema: arg.schema,
+            position: arg.position,
+            property: arg.column.$metadata.map,
+          }));
+    });
   });
 });

--- a/spec/util.js
+++ b/spec/util.js
@@ -1,0 +1,30 @@
+import { flow, omit, isEqual } from 'lodash/fp';
+import sinon from 'sinon';
+import $ from 'lib/jquery';
+
+export var $container = $('body > #container');
+if ($container.length === 0) {
+  $container = $('<div id="container" />').appendTo('body');
+}
+
+export function cleanup() {
+  $container.empty();
+}
+
+export function objectPartialMatch(propsToOmit, expected) {
+  const omitProps = omit(propsToOmit);
+  return sinon.match(
+    flow(
+      // function (actual) {
+      //   console.log('Actual', JSON.stringify(omitProps(actual)));
+      //   console.log('Expected', JSON.stringify(expected));
+      //   return actual;
+      // },
+      omitProps,
+      isEqual(expected)
+      // result => {
+      //   console.log('result', result);
+      //   return result;
+      // }
+    ), 'matching ' + JSON.stringify(expected) + ' without [' + propsToOmit.map(prop => `"${prop}"`).join(', ') + '] properties');
+}


### PR DESCRIPTION
Localizing the 'Save' and 'Cancel' buttons of the popup control.
Fixing a bug in the editable projection, where it falls back to the default popup prompt function on complex model.
Adding unit tests.

**To Wei:** please help test this change
