### PR TITLE
set checkbox in head unchecked when grid is empty

### DIFF
--- a/js/vnext/projection/selection.js
+++ b/js/vnext/projection/selection.js
@@ -85,7 +85,7 @@ function selectionProjectionHandler(state, {
     const selectableCount = _.filter(state.items.slice(), selectable).length;
     const selectedCount = _.filter(selected, key => selectable(this.itemWithKey(key))).length;
 
-    selectedAll = selectedCount === selectableCount;
+    selectedAll = selectableCount !== 0 && selectedCount === selectableCount;
   }
 
   const columns = [{


### PR DESCRIPTION
Code change:
One line change.
Set checkbox in table header unchecked when the count of selectable item is 0. 