### PR TITLE
Patch issue with passing in DataSource object in config.dataSource

### DIFF
--- a/js/vnext/grid-view.js
+++ b/js/vnext/grid-view.js
@@ -22,6 +22,7 @@ import {
   MemoryDataSource,
   JSDataDataSource,
   ODataDataSource,
+  DataSource,
 } from './data-source';
 
 function defaultsDeep(dest, src) {
@@ -375,7 +376,7 @@ export class GridView extends Backbone.View {
    */
   set(config = {}, callback = _.noop) {
     // backward compatibility
-    if (_.has(config, 'dataSource')) {
+    if (_.has(config, 'dataSource') && !(config.dataSource instanceof DataSource)) {
       const dataSource = config.dataSource;
 
       config.query = _.defaults({}, config.query, _.pick(dataSource, [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "name": "Ahmed Kamel"
   },
   "main": "dist/projection-grid.js",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This is to fix issue where config.query gets overridden with properties of the DataSource object if it is passed in through config.dataSource to the grid view factory.

From the grid view factory interface, it supports passing in an instance of the DataSource object explicitly so this should be a supported scenario.