### PR TITLE
Fix selection client side error

### DIFF
--- a/js/vnext/projection/selection.js
+++ b/js/vnext/projection/selection.js
@@ -24,10 +24,12 @@ function changeSelectAll(e) {
 }
 
 export function setSelectRow(gridView, key, checked) {
-  const { resolver } = gridView.get('selection');
-  const selection = checked ? resolver.selectRow(key) : resolver.deselectRow(key);
+  if (key !== null && key !== undefined) {
+    const { resolver } = gridView.get('selection');
+    const selection = checked ? resolver.selectRow(key) : resolver.deselectRow(key);
 
-  updateSelection(gridView, selection);
+    updateSelection(gridView, selection);
+  }
 }
 
 function changeSelectRow(e) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "name": "Ahmed Kamel"
   },
   "main": "dist/projection-grid.js",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Rows without keys are non-selectable. Our selection API `setSelectRow` need to protect the caller from selecting them.