### PR TITLE
Add disable shift key option

### DIFF
--- a/js/vnext/projection/range-selection.js
+++ b/js/vnext/projection/range-selection.js
@@ -2,16 +2,16 @@ import _ from 'underscore';
 
 function changeSelectRow(e) {
   const key = this.keyOfElement(e.target);
+  const selection = this.get('selection');
   const rangeSelection = this.get('rangeSelection');
 
   // if the user didn't press shift key or the disableShiftKey option is set to true,
   // act as a simple click select.
-  if (!e.shiftKey || this.disableShiftKey) {
+  if (!e.shiftKey || selection.disableShiftKey) {
     rangeSelection.preSelect = key;
     return;
   }
 
-  const selection = this.get('selection');
   const selected = selection.selected;
   const selectable = selection.selectable;
   const preSelect = rangeSelection.preSelect;

--- a/js/vnext/projection/range-selection.js
+++ b/js/vnext/projection/range-selection.js
@@ -4,7 +4,9 @@ function changeSelectRow(e) {
   const key = this.keyOfElement(e.target);
   const rangeSelection = this.get('rangeSelection');
 
-  if (!e.shiftKey) {
+  // if the user didn't press shift key or the disableShiftKey option is set to true,
+  // act as a simple click select.
+  if (!e.shiftKey || this.disableShiftKey) {
     rangeSelection.preSelect = key;
     return;
   }

--- a/js/vnext/projection/sortable-header.js
+++ b/js/vnext/projection/sortable-header.js
@@ -1,8 +1,6 @@
 import _ from 'underscore';
 import sortableHeaderTemplate from './sortable-header.jade';
 
-const regexKey = /\s*(-)?\s*(\w+)/;
-
 // Reorder column data referring to 'column.sortable'.
 // 'column.sortable' takes four types of values: boolean, number, string and function.
 function reorder(e) {
@@ -74,7 +72,7 @@ function sortableHeaderProjectionHandler(state, {
         const direction = column.name === name ? column.sortable.direction[directionIndex] : 0;
         const ariaSort = direction > 0 ? 'ascending' : direction < 0 ? 'descending' : 'none';
 
-        patchCell.attributes = _.defaults({ 'aria-sort': ariaSort, tabindex: 0 }, cell.attributes);
+        patchCell.attributes = _.defaults({ 'aria-sort': ariaSort, 'tabindex': 0 }, cell.attributes);
 
         /**
          * @callback SortableHeaderTemplate

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "name": "Ahmed Kamel"
   },
   "main": "dist/projection-grid.js",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
the behavior of range selection is hard to identify under a tree-view plugin. need to create an option to disable it.

fix some eslint errors as well.