### PR TITLE
fix a jsdata bug that slice is not a function

### DIFF
--- a/js/vnext/data-source/js-data.js
+++ b/js/vnext/data-source/js-data.js
@@ -44,10 +44,16 @@ export class JSDataDataSource extends DataSource {
 
     return this._resource
       .findAll(translateParams(this, _.omit(params, 'options')), options)
-      .then(data => ({
-        items: data.slice(),
-        totalCount: data.totalCount || 0,
-      }));
+      .then(data => {
+        if (_.isArray(data)) {
+          return ({
+            items: data.slice(),
+            totalCount: data.totalCount || 0,
+          });
+        } else {
+          throw data; // propagate error out
+        }
+      });
   }
 
   get resource() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "name": "Ahmed Kamel"
   },
   "main": "dist/projection-grid.js",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.1-alpha.3",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
When js data call failed, we will see error "slice is not a function". Add the check of data, and propagate error out to parent in this scenario.