### PR TITLE
Add the role attribute for the grid

### DIFF
--- a/js/vnext/layout/flex-fixed.jade
+++ b/js/vnext/layout/flex-fixed.jade
@@ -5,12 +5,12 @@
     'table-layout': 'fixed',
   };
 
-.table-container.flex-layout
+.table-container.flex-layout(role='grid')
   .fixed-header
-    div.table.fixed-header(style=tableStyle, class=classes, role='grid')&attributes(headerAttributes)
+    div.table.fixed-header(style=tableStyle, class=classes)&attributes(headerAttributes)
       div.thead.header
   .viewport
-    div.table.data-table(style=tableStyle, class=classes, role='grid')&attributes(dataTableAttributes)
+    div.table.data-table(style=tableStyle, class=classes)&attributes(dataTableAttributes)
       div.tbody(role='rowgroup')
         div.tr.top-filler(role='presentation')
         div.tr.bottom-filler(role='presentation')

--- a/js/vnext/layout/flex-sticky.jade
+++ b/js/vnext/layout/flex-sticky.jade
@@ -5,11 +5,11 @@
     'table-layout': 'fixed',
   };
 
-.table-container.flex-layout
-  div.table.sticky-header(style=tableStyle, class=classes, role='grid')&attributes(headerAttributes)
+.table-container.flex-layout(role='grid')
+  div.table.sticky-header(style=tableStyle, class=classes)&attributes(headerAttributes)
     div.thead.header
   .sticky-header-filler
-  div.table.data-table(style=tableStyle, class=classes, role='grid')&attributes(dataTableAttributes)
+  div.table.data-table(style=tableStyle, class=classes)&attributes(dataTableAttributes)
     div.tbody(role='rowgroup')
       div.tr.top-filler(role='presentation')
       div.tr.bottom-filler(role='presentation')

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "name": "Ahmed Kamel"
   },
   "main": "dist/projection-grid.js",
-  "version": "0.2.1-alpha.9",
+  "version": "0.2.1-alpha.10",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
remove role='grid' from header and data table. And add it to table container. 
This will allow screen readers to correctly associate column headers with the cells.